### PR TITLE
Ceres slice write tests

### DIFF
--- a/ceres.py
+++ b/ceres.py
@@ -592,7 +592,7 @@ class CeresSlice(object):
         packedValues = packedGap + packedValues
         byteOffset -= byteGap
 
-    with file(self.fsPath, 'r+b') as fileHandle:
+    with open(self.fsPath, 'r+b') as fileHandle:
       try:
         fileHandle.seek(byteOffset)
       except IOError:
@@ -616,7 +616,7 @@ class CeresSlice(object):
       return
 
     self.node.clearSliceCache()
-    with file(self.fsPath, 'r+b') as fileHandle:
+    with open(self.fsPath, 'r+b') as fileHandle:
       fileHandle.seek(byteOffset)
       fileData = fileHandle.read()
       if fileData:

--- a/ceres.py
+++ b/ceres.py
@@ -583,11 +583,10 @@ class CeresSlice(object):
 
     byteGap = byteOffset - filesize
     if byteGap > 0:  # pad the allowable gap with nan's
-
-      if byteGap > MAX_SLICE_GAP:
+      pointGap = byteGap / DATAPOINT_SIZE
+      if pointGap > MAX_SLICE_GAP:
         raise SliceGapTooLarge()
       else:
-        pointGap = byteGap / DATAPOINT_SIZE
         packedGap = PACKED_NAN * pointGap
         packedValues = packedGap + packedValues
         byteOffset -= byteGap


### PR DESCRIPTION
A bunch of tests for CeresSlice including a bunch for write()

Also included is a bugfix from @vladimir-smirnov-sociomantic for point gap calculation which was caught by the new tests