### PR TITLE
Fixes to Ceres read behavior problems found in new unit tests

### DIFF
--- a/ceres.py
+++ b/ceres.py
@@ -438,8 +438,8 @@ or `none` (See :func:`slices`)
       self.readMetadata()
 
     # Normalize the timestamps to fit proper intervals
-    fromTime = int(fromTime - (fromTime % self.timeStep) + self.timeStep)
-    untilTime = int(untilTime - (untilTime % self.timeStep) + self.timeStep)
+    fromTime = int(fromTime - (fromTime % self.timeStep))
+    untilTime = int(untilTime - (untilTime % self.timeStep))
 
     sliceBoundary = None  # to know when to split up queries across slices
     resultValues = []

--- a/ceres.py
+++ b/ceres.py
@@ -446,28 +446,28 @@ or `none` (See :func:`slices`)
     earliestData = None
 
     for slice in self.slices:
+      # If there was a prior slice covering the requested interval, dont ask for that data again
+      if (sliceBoundary is not None) and untilTime > sliceBoundary:
+        requestUntilTime = sliceBoundary
+      else:
+        requestUntilTime = untilTime
+
       # if the requested interval starts after the start of this slice
       if fromTime >= slice.startTime:
         try:
-          series = slice.read(fromTime, untilTime)
+          series = slice.read(fromTime, requestUntilTime)
         except NoData:
           break
 
         earliestData = series.startTime
 
-        rightMissing = (untilTime - series.endTime) / self.timeStep
-        rightNulls = [None for i in range(rightMissing - len(resultValues))]
+        rightMissing = (requestUntilTime - series.endTime) / self.timeStep
+        rightNulls = [None for i in range(rightMissing)]
         resultValues = series.values + rightNulls + resultValues
         break
 
       # or if slice contains data for part of the requested interval
       elif untilTime >= slice.startTime:
-        # Split the request up if it straddles a slice boundary
-        if (sliceBoundary is not None) and untilTime > sliceBoundary:
-          requestUntilTime = sliceBoundary
-        else:
-          requestUntilTime = untilTime
-
         try:
           series = slice.read(slice.startTime, requestUntilTime)
         except NoData:

--- a/tests/test_ceres.py
+++ b/tests/test_ceres.py
@@ -636,12 +636,10 @@ class CeresNodeReadTest(TestCase):
         pass
       read_metadata_mock.assert_called_once_with()
 
-  @skip
   def test_read_normalizes_from_time(self):
     self.ceres_node.read(1210, 1260)
     self.ceres_slices[0].read.assert_called_once_with(1200, 1260)
 
-  @skip
   def test_read_normalizes_until_time(self):
     self.ceres_node.read(1200, 1270)
     self.ceres_slices[0].read.assert_called_once_with(1200, 1260)
@@ -655,16 +653,14 @@ class CeresNodeReadTest(TestCase):
     result = self.ceres_node.read(1200, 1500)
     self.assertEqual([None] * 5, result.values)
 
-  @skip
   def test_read_pads_points_missing_before_series(self):
     result = self.ceres_node.read(540, 1200)
-    self.assertEqual(None, result.values[0])
+    self.assertEqual([None] + [0] * 10, result.values)
 
   def test_read_pads_points_missing_after_series(self):
     result = self.ceres_node.read(1200, 1860)
     self.assertEqual(None, result.values[-1])
 
-  @skip
   def test_read_goes_across_slices(self):
     self.ceres_node.read(900, 1500)
     self.ceres_slices[0].read.assert_called_once_with(1200, 1500)
@@ -678,7 +674,6 @@ class CeresNodeReadTest(TestCase):
     result = self.ceres_node.read(900, 1860)
     self.assertEqual(None, result.values[-1])
 
-  @skip
   def test_read_pads_points_missing_between_slices(self):
     self.ceres_slices[1] = make_slice_mock(600, 1140, 60)
     result = self.ceres_node.read(900, 1500)


### PR DESCRIPTION
Several fixes here for problems found in unit tests.

bd728d6 changes read behavior from always rounding to the next minute to using the current minute instead. That is, previously if timestamp 60000 were requested, 60060 would be returned. I'm sure there was a motivation here, but I can't think of one. That being the case, this behavior is quite unintuitive which adjusting the unit tests to support makes clear. It also causes points from the future to attempt to be loaded when the current time is used as the commit text notes.

45fea85 is a fix to use the sliceBoundary when multiple slices need to be queried in the last query. Previously, only the first and middle queries would ensure they dont request data already requested in later (rightmost) slices. The final slice queried would have the entire range asked of it.