### PR TITLE
Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 language: python
 python:
     - 2.7
+    - 3.2
+    - 3.3
+    - 3.4
+    - 3.5
     - "pypy"
 install:
     - pip install -r test_requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
     - 3.5
     - "pypy"
 install:
-    - pip install -r test_requirements.txt --use-mirrors
+    - pip install -r test_requirements.txt
     - python setup.py install
 script:
     - nosetests

--- a/bin/ceres-node-create
+++ b/bin/ceres-node-create
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 from optparse import OptionParser
@@ -28,7 +29,7 @@ else:
   tree = getTree(fsPath)
 
   if not tree:
-    print "error: %s is not in a ceres tree" % fsPath
+    print("error: %s is not in a ceres tree" % fsPath)
     sys.exit(1)
 
   nodePath = tree.getNodePath(fsPath)

--- a/bin/ceres-node-read
+++ b/bin/ceres-node-read
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 import time
@@ -31,7 +32,7 @@ else:
   tree = getTree(fsPath)
 
   if not tree:
-    print "error: %s is not in a ceres tree" % fsPath
+    print("error: %s is not in a ceres tree" % fsPath)
     sys.exit(1)
 
   nodePath = tree.getNodePath(fsPath)
@@ -40,6 +41,6 @@ results = tree.fetch(nodePath, options.fromtime, options.untiltime)
 
 for (timestamp, value) in results:
   if options.batch:
-    print "%d\t%s" % (timestamp, value)
+    print("%d\t%s" % (timestamp, value))
   else:
-    print "%s\t%s" % (time.ctime(timestamp), value)
+    print("%s\t%s" % (time.ctime(timestamp), value))

--- a/bin/ceres-node-write
+++ b/bin/ceres-node-write
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 import time
@@ -31,7 +32,7 @@ else:
   tree = getTree(fsPath)
 
   if not tree:
-    print "error: %s is not in a ceres tree" % fsPath
+    print("error: %s is not in a ceres tree" % fsPath)
     sys.exit(1)
 
   nodePath = tree.getNodePath(fsPath)
@@ -53,7 +54,7 @@ for datapoint in args[1:]:
 datapoints.sort()
 
 if not args:
-  print "error: no datapoints specified"
+  print("error: no datapoints specified")
   parser.print_usage()
   sys.exit(1)
 

--- a/bin/ceres-tree-create
+++ b/bin/ceres-tree-create
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 from optparse import OptionParser
@@ -11,7 +12,7 @@ parser.add_option('--verbose', action='store_true')
 options, args = parser.parse_args()
 
 if not args:
-  print "You must specify a root directory for the tree"
+  print("You must specify a root directory for the tree")
   parser.print_usage()
   sys.exit(1)
 
@@ -33,6 +34,6 @@ for arg in args[1:]:
   props[prop] = value
 
 if options.verbose:
-  print "Creating tree at %s with props=%s" % (root_dir, props)
+  print("Creating tree at %s with props=%s" % (root_dir, props))
 
 tree = CeresTree.createTree(root_dir, **props)

--- a/bin/ceres-tree-find
+++ b/bin/ceres-tree-find
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 from optparse import OptionParser
@@ -23,6 +24,6 @@ tree = CeresTree(root_dir)
 
 for node in tree.find(pattern, fromTime=options.fromtime, untilTime=options.untiltime):
   if options.fspath:
-    print node.fsPath
+    print(node.fsPath)
   else:
-    print node.nodePath
+    print(node.nodePath)

--- a/bin/convert-wsp-to-ceres
+++ b/bin/convert-wsp-to-ceres
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 import os
@@ -16,7 +17,7 @@ parser.add_option('--delete', action='store_true')
 options, args = parser.parse_args()
 
 if not args:
-  print "You must specify a wsp file"
+  print("You must specify a wsp file")
   parser.print_usage()
   sys.exit(1)
 
@@ -27,38 +28,38 @@ metric_name = basename(wsp_file)[:-4]  # strip .wsp
 ceres_node_dir = join(wsp_dir, metric_name)
 
 if isdir(ceres_node_dir):
-  print "error: ceres node directory already exists (%s)" % ceres_node_dir
+  print("error: ceres node directory already exists (%s)" % ceres_node_dir)
   sys.exit(1)
 
 tree = ceres.getTree(ceres_node_dir)
 
 if not tree:
-  print "error: the specified path is not in a ceres tree"
+  print("error: the specified path is not in a ceres tree")
   sys.exit(1)
 
 nodePath = tree.getNodePath(ceres_node_dir)
 
 if options.verbose:
-  print "extracting datapoints from wsp file"
+  print("extracting datapoints from wsp file")
 
 timeInfo, values = whisper.fetch(wsp_file, fromTime=0, untilTime=time.time())
-datapoints = zip(xrange(*timeInfo), values)
+datapoints = zip(range(*timeInfo), values)
 datapoints = [(t, v) for (t, v) in datapoints if v is not None]
 
 if options.verbose:
-  print "creating ceres node %s" % nodePath
+  print("creating ceres node %s" % nodePath)
 
 node = tree.createNode(nodePath)
 
 if options.verbose:
-  print "importing %d datapoints" % len(datapoints)
+  print("importing %d datapoints" % len(datapoints))
 
 node.write(datapoints)
 
 if options.delete:
   if options.verbose:
-    print "deleting original wsp file: %s" % wsp_file
+    print("deleting original wsp file: %s" % wsp_file)
   os.unlink(wsp_file)
 
 if options.verbose:
-  print "conversion successful"
+  print("conversion successful")

--- a/bin/slicecat
+++ b/bin/slicecat
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 
 import sys
 import os
@@ -27,5 +28,5 @@ format = '!' + ('d' * (len(packedValues) / 8))
 values = struct.unpack(format, packedValues)
 
 for value in values:
-  print "[%d]\t%s\t%s" % (timestamp, time.ctime(timestamp), value)
+  print("[%d]\t%s\t%s" % (timestamp, time.ctime(timestamp), value))
   timestamp += timeStep

--- a/ceres.py
+++ b/ceres.py
@@ -748,8 +748,8 @@ class CeresSlice(object):
         os.unlink(self.fsPath)
         raise SliceDeleted()
 
-  def __cmp__(self, other):
-    return cmp(self.startTime, other.startTime)
+  def __lt__(self, other):
+    return self.startTime < other.startTime
 
 
 class TimeSeriesData(object):

--- a/ceres.py
+++ b/ceres.py
@@ -14,17 +14,18 @@
 #
 #
 
-# Ceres requires Python 2.6 or newer
+# Ceres requires Python 2.7 or newer
+import itertools
 import os
 import struct
 import json
 import errno
 from math import isnan
-from itertools import izip
 from os.path import isdir, exists, join, dirname, abspath, getsize, getmtime
 from glob import glob
 from bisect import bisect_left
 
+izip = getattr(itertools, 'izip', zip)
 
 TIMESTAMP_FORMAT = "!L"
 TIMESTAMP_SIZE = struct.calcsize(TIMESTAMP_FORMAT)
@@ -35,8 +36,8 @@ PACKED_NAN = struct.pack(DATAPOINT_FORMAT, NAN)
 MAX_SLICE_GAP = 80
 DEFAULT_TIMESTEP = 60
 DEFAULT_SLICE_CACHING_BEHAVIOR = 'none'
-SLICE_PERMS = 0644
-DIR_PERMS = 0755
+SLICE_PERMS = 0o644
+DIR_PERMS = 0o755
 
 
 class CeresTree(object):
@@ -312,8 +313,8 @@ used
       metadata = json.load(open(self.metadataFile, 'r'))
       self.timeStep = int(metadata['timeStep'])
       return metadata
-    except (KeyError, IOError, ValueError), e:
-      raise CorruptNode(self, "Unable to parse node metadata: %s" % e.message)
+    except (KeyError, IOError, ValueError) as e:
+      raise CorruptNode(self, "Unable to parse node metadata: %s" % e.args)
 
   def writeMetadata(self, metadata):
     """Writes new metadata to disk
@@ -461,7 +462,7 @@ or `none` (See :func:`slices`)
 
         earliestData = series.startTime
 
-        rightMissing = (requestUntilTime - series.endTime) / self.timeStep
+        rightMissing = (requestUntilTime - series.endTime) // self.timeStep
         rightNulls = [None for i in range(rightMissing)]
         resultValues = series.values + rightNulls + resultValues
         break
@@ -475,7 +476,7 @@ or `none` (See :func:`slices`)
 
         earliestData = series.startTime
 
-        rightMissing = (requestUntilTime - series.endTime) / self.timeStep
+        rightMissing = (requestUntilTime - series.endTime) // self.timeStep
         rightNulls = [None for i in range(rightMissing)]
         resultValues = series.values + rightNulls + resultValues
 
@@ -484,12 +485,12 @@ or `none` (See :func:`slices`)
 
     # The end of the requested interval predates all slices
     if earliestData is None:
-      missing = int(untilTime - fromTime) / self.timeStep
+      missing = int(untilTime - fromTime) // self.timeStep
       resultValues = [None for i in range(missing)]
 
     # Left pad nulls if the start of the requested interval predates all slices
     else:
-      leftMissing = (earliestData - fromTime) / self.timeStep
+      leftMissing = (earliestData - fromTime) // self.timeStep
       leftNulls = [None for i in range(leftMissing)]
       resultValues = leftNulls + resultValues
 
@@ -634,7 +635,7 @@ class CeresSlice(object):
 
   @property
   def endTime(self):
-    return self.startTime + ((getsize(self.fsPath) / DATAPOINT_SIZE) * self.timeStep)
+    return self.startTime + ((getsize(self.fsPath) // DATAPOINT_SIZE) * self.timeStep)
 
   @property
   def mtime(self):
@@ -655,7 +656,7 @@ class CeresSlice(object):
       raise InvalidRequest("requested time range (%d, %d) precedes this slice: %d" % (
           fromTime, untilTime, self.startTime))
 
-    pointOffset = timeOffset / self.timeStep
+    pointOffset = timeOffset // self.timeStep
     byteOffset = pointOffset * DATAPOINT_SIZE
 
     if byteOffset >= getsize(self.fsPath):
@@ -665,11 +666,11 @@ class CeresSlice(object):
     fileHandle.seek(byteOffset)
 
     timeRange = int(untilTime - fromTime)
-    pointRange = timeRange / self.timeStep
+    pointRange = timeRange // self.timeStep
     byteRange = pointRange * DATAPOINT_SIZE
     packedValues = fileHandle.read(byteRange)
 
-    pointsReturned = len(packedValues) / DATAPOINT_SIZE
+    pointsReturned = len(packedValues) // DATAPOINT_SIZE
     format = '!' + ('d' * pointsReturned)
     values = struct.unpack(format, packedValues)
     values = [v if not isnan(v) else None for v in values]
@@ -684,7 +685,7 @@ class CeresSlice(object):
   def write(self, sequence):
     beginningTime = sequence[0][0]
     timeOffset = beginningTime - self.startTime
-    pointOffset = timeOffset / self.timeStep
+    pointOffset = timeOffset // self.timeStep
     byteOffset = pointOffset * DATAPOINT_SIZE
 
     values = [v for t, v in sequence]
@@ -693,7 +694,7 @@ class CeresSlice(object):
 
     try:
       filesize = getsize(self.fsPath)
-    except OSError, e:
+    except OSError as e:
       if e.errno == errno.ENOENT:
         raise SliceDeleted()
       else:
@@ -701,7 +702,7 @@ class CeresSlice(object):
 
     byteGap = byteOffset - filesize
     if byteGap > 0:  # pad the allowable gap with nan's
-      pointGap = byteGap / DATAPOINT_SIZE
+      pointGap = byteGap // DATAPOINT_SIZE
       if pointGap > MAX_SLICE_GAP:
         raise SliceGapTooLarge()
       else:
@@ -713,8 +714,8 @@ class CeresSlice(object):
       try:
         fileHandle.seek(byteOffset)
       except IOError:
-        print " IOError: fsPath=%s byteOffset=%d size=%d sequence=%s" % (
-            self.fsPath, byteOffset, filesize, sequence)
+        # print " IOError: fsPath=%s byteOffset=%d size=%d sequence=%s" % (
+        #   self.fsPath, byteOffset, filesize, sequence)
         raise
       fileHandle.write(packedValues)
 
@@ -727,7 +728,7 @@ class CeresSlice(object):
     if timeOffset < 0:
       return
 
-    pointOffset = timeOffset / self.timeStep
+    pointOffset = timeOffset // self.timeStep
     byteOffset = pointOffset * DATAPOINT_SIZE
     if not byteOffset:
       return
@@ -762,7 +763,7 @@ class TimeSeriesData(object):
 
   @property
   def timestamps(self):
-    return xrange(self.startTime, self.endTime, self.timeStep)
+    return range(self.startTime, self.endTime, self.timeStep)
 
   def __iter__(self):
     return izip(self.timestamps, self.values)
@@ -779,7 +780,7 @@ class TimeSeriesData(object):
       if timestamp < self.startTime:
         continue
 
-      index = int((timestamp - self.startTime) / self.timeStep)
+      index = int((timestamp - self.startTime) // self.timeStep)
 
       try:
         if self.values[index] is None:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 nose==1.3.6
 mock==1.0.1
 flake8==2.4.0
-unittest2==1.0.1

--- a/tests/test_ceres.py
+++ b/tests/test_ceres.py
@@ -20,11 +20,12 @@ from ceres import getTree, CorruptNode, NoData, NodeDeleted, NodeNotFound, Slice
 
 def fetch_mock_open_writes(open_mock):
   handle = open_mock()
-  #XXX Python3 compability since a write can be bytes or str
+  # XXX Python3 compability since a write can be bytes or str
   try:
     return b''.join([c[0][0] for c in handle.write.call_args_list])
   except TypeError:
     return ''.join([c[0][0] for c in handle.write.call_args_list])
+
 
 def make_slice_mock(start, end, step):
   slice_mock = Mock(spec=CeresSlice)
@@ -772,6 +773,17 @@ class CeresSliceTest(TestCase):
       ceres_slice.deleteBefore(360)
       # Seek from 300 (start of file) to 360 (1 datapointpoint)
       open_mock.return_value.seek.assert_any_call(1 * DATAPOINT_SIZE)
+
+  @patch('ceres.exists', Mock(return_value=True))
+  def test_slices_are_sortable(self):
+    ceres_slices = [
+      CeresSlice(self.ceres_node, 300, 60),
+      CeresSlice(self.ceres_node, 600, 60),
+      CeresSlice(self.ceres_node, 0, 60)]
+
+    expected_order = [0, 300, 600]
+    result_order = [slice.startTime for slice in sorted(ceres_slices)]
+    self.assertEqual(expected_order, result_order)
 
 
 class CeresSliceWriteTest(TestCase):

--- a/tests/test_ceres.py
+++ b/tests/test_ceres.py
@@ -1,12 +1,15 @@
-try:
-  from unittest2 import TestCase, skip
-except ImportError:
-  from unittest import TestCase, skip
+from unittest import TestCase, skip
 
 import errno
 
 from mock import ANY, Mock, call, mock_open, patch
 from os import path
+
+try:
+  import __builtin__ as builtins
+except ImportError:
+  import builtins
+
 
 from ceres import CeresNode, CeresSlice, CeresTree
 from ceres import DATAPOINT_SIZE, DEFAULT_SLICE_CACHING_BEHAVIOR, DEFAULT_TIMESTEP, DIR_PERMS,\
@@ -17,8 +20,11 @@ from ceres import getTree, CorruptNode, NoData, NodeDeleted, NodeNotFound, Slice
 
 def fetch_mock_open_writes(open_mock):
   handle = open_mock()
-  return ''.join([c[0][0] for c in handle.write.call_args_list])
-
+  #XXX Python3 compability since a write can be bytes or str
+  try:
+    return b''.join([c[0][0] for c in handle.write.call_args_list])
+  except TypeError:
+    return ''.join([c[0][0] for c in handle.write.call_args_list])
 
 def make_slice_mock(start, end, step):
   slice_mock = Mock(spec=CeresSlice)
@@ -30,7 +36,7 @@ def make_slice_mock(start, end, step):
     startTime, endTime = args
     result_start = max(startTime, start)
     result_end = min(endTime, end)
-    points = (result_end - result_start) / step
+    points = (result_end - result_start) // step
     return TimeSeriesData(result_start, result_end, step, [0] * points)
 
   slice_mock.read.side_effect = side_effect
@@ -56,7 +62,7 @@ class ModuleFunctionsTest(TestCase):
 
 class TimeSeriesDataTest(TestCase):
   def setUp(self):
-    self.time_series = TimeSeriesData(0, 50, 5, [float(x) for x in xrange(0, 10)])
+    self.time_series = TimeSeriesData(0, 50, 5, [float(x) for x in range(0, 10)])
 
   def test_timestamps_property(self):
     self.assertEqual(10, len(self.time_series.timestamps))
@@ -71,7 +77,7 @@ class TimeSeriesDataTest(TestCase):
 
   def test_merge_no_missing(self):
     # merge only has effect if time series has no gaps
-    other_series = TimeSeriesData(0, 25, 5, [float(x * x) for x in xrange(1, 6)])
+    other_series = TimeSeriesData(0, 25, 5, [float(x * x) for x in range(1, 6)])
     original_values = list(self.time_series)
     self.time_series.merge(other_series)
     self.assertEqual(original_values, list(self.time_series))
@@ -83,7 +89,7 @@ class TimeSeriesDataTest(TestCase):
 
   def test_merge_with_holes(self):
     values = []
-    for x in xrange(0, 10):
+    for x in range(0, 10):
       if x % 2 == 0:
         values.append(x)
       else:
@@ -115,7 +121,7 @@ class CeresTreeTest(TestCase):
   @patch('os.makedirs')
   def test_create_tree_new_dir(self, makedirs_mock, ceres_tree_init_mock):
     ceres_tree_init_mock.return_value = None
-    with patch('__builtin__.open', mock_open()) as open_mock:
+    with patch.object(builtins, 'open', mock_open()) as open_mock:
       CeresTree.createTree('/graphite/storage/ceres')
       makedirs_mock.assert_called_once_with('/graphite/storage/ceres/.ceres-tree', DIR_PERMS)
       self.assertFalse(open_mock.called)
@@ -126,7 +132,7 @@ class CeresTreeTest(TestCase):
   @patch('os.makedirs')
   def test_create_tree_existing_dir(self, makedirs_mock, ceres_tree_init_mock):
     ceres_tree_init_mock.return_value = None
-    with patch('__builtin__.open', mock_open()) as open_mock:
+    with patch.object(builtins, 'open', mock_open()) as open_mock:
       CeresTree.createTree('/graphite/storage/ceres')
       self.assertFalse(makedirs_mock.called)
       self.assertFalse(open_mock.called)
@@ -139,7 +145,7 @@ class CeresTreeTest(TestCase):
     props = {
       "foo_prop": "foo_value",
       "bar_prop": "bar_value"}
-    with patch('__builtin__.open', mock_open()) as open_mock:
+    with patch.object(builtins, 'open', mock_open()) as open_mock:
       CeresTree.createTree('/graphite/storage/ceres', **props)
       for (prop, value) in props.items():
         open_mock.assert_any_call(path.join('/graphite/storage/ceres', '.ceres-tree', prop), 'w')
@@ -290,7 +296,7 @@ class CeresNodeTest(TestCase):
 
     open_mock = mock_open()
     metadata = dict(timeStep=60, aggregationMethod='avg')
-    with patch('__builtin__.open', open_mock):
+    with patch.object(builtins, 'open', open_mock):
       self.ceres_node.writeMetadata(metadata)
     self.assertEquals(json.dumps(metadata), fetch_mock_open_writes(open_mock))
 
@@ -300,13 +306,13 @@ class CeresNodeTest(TestCase):
     metadata = dict(timeStep=60, aggregationMethod='avg')
     json_metadata = json.dumps(metadata)
     open_mock = mock_open(read_data=json_metadata)
-    with patch('__builtin__.open', open_mock):
+    with patch.object(builtins, 'open', open_mock):
       self.ceres_node.readMetadata()
     open_mock().read.assert_called_once()
     self.assertEqual(60, self.ceres_node.timeStep)
 
   def test_read_metadata_returns_corrupt_if_json_error(self):
-    with patch('__builtin__.open', mock_open()):
+    with patch.object(builtins, 'open', mock_open()):
       self.assertRaises(CorruptNode, self.ceres_node.readMetadata)
 
   def test_set_slice_caching_behavior_validates_names(self):
@@ -346,7 +352,7 @@ class CeresNodeTest(TestCase):
     read_slices_mock = Mock(return_value=[])
     with patch('ceres.CeresNode.readSlices', new=read_slices_mock):
       slice_iter = self.ceres_node.slices
-      self.assertEquals(cached_contents, slice_iter.next())
+      self.assertEquals(cached_contents, next(slice_iter))
       # We should be yielding cached before trying to read
       self.assertFalse(read_slices_mock.called)
 
@@ -358,12 +364,12 @@ class CeresNodeTest(TestCase):
     read_slices_mock = Mock(return_value=[(0, 60)])
     with patch('ceres.CeresNode.readSlices', new=read_slices_mock):
       slice_iter = self.ceres_node.slices
-      slice_iter.next()
+      next(slice_iter)
 
       # *now* we expect to read from disk
       try:
         while True:
-          slice_iter.next()
+          next(slice_iter)
       except StopIteration:
         pass
 
@@ -374,7 +380,7 @@ class CeresNodeTest(TestCase):
     read_slices_mock = Mock(return_value=[(0, 60)])
     with patch('ceres.CeresNode.readSlices', new=read_slices_mock):
       slice_iter = self.ceres_node.slices
-      slice_iter.next()
+      next(slice_iter)
 
     read_slices_mock.assert_called_once_with()
 
@@ -383,7 +389,7 @@ class CeresNodeTest(TestCase):
     read_slices_mock = Mock(return_value=[(0, 60)])
     with patch('ceres.CeresNode.readSlices', new=read_slices_mock):
       slice_iter = self.ceres_node.slices
-      slice_iter.next()
+      next(slice_iter)
 
     read_slices_mock.assert_called_once_with()
 
@@ -392,7 +398,7 @@ class CeresNodeTest(TestCase):
     read_slices_mock = Mock(return_value=[(0, 60)])
     with patch('ceres.CeresNode.readSlices', new=read_slices_mock):
       slice_iter = self.ceres_node.slices
-      slice_iter.next()
+      next(slice_iter)
 
     read_slices_mock.assert_called_once_with()
 
@@ -708,7 +714,7 @@ class CeresSliceTest(TestCase):
     self.assertRaises(SliceDeleted, ceres_slice.deleteBefore, 60)
 
   @patch('ceres.exists', Mock(return_value=True))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_delete_before_returns_if_time_earlier_than_start(self, open_mock):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     # File starts at timestamp 300, delete points before timestamp 60
@@ -716,14 +722,14 @@ class CeresSliceTest(TestCase):
     open_mock.assert_has_calls([])  # no calls
 
   @patch('ceres.exists', Mock(return_value=True))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_delete_before_returns_if_time_less_than_step_earlier_than_start(self, open_mock):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     ceres_slice.deleteBefore(299)
     open_mock.assert_has_calls([])
 
   @patch('ceres.exists', Mock(return_value=True))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_delete_before_returns_if_time_same_as_start(self, open_mock):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     ceres_slice.deleteBefore(300)
@@ -734,13 +740,13 @@ class CeresSliceTest(TestCase):
   def test_delete_before_clears_slice_cache(self):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     open_mock = mock_open(read_data='foo')  # needs to be non-null for this test
-    with patch('__builtin__.open', open_mock):
+    with patch.object(builtins, 'open', open_mock):
       with patch('ceres.CeresNode.clearSliceCache') as clear_slice_cache_mock:
         ceres_slice.deleteBefore(360)
         clear_slice_cache_mock.assert_called_once_with()
 
   @patch('ceres.exists', Mock(return_value=True))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_delete_before_deletes_file_if_no_more_data(self, open_mock):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     with patch('ceres.os.unlink') as unlink_mock:
@@ -752,7 +758,7 @@ class CeresSliceTest(TestCase):
 
   @patch('ceres.exists', Mock(return_value=True))
   @patch('ceres.os.unlink', Mock())
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_delete_before_raises_slice_deleted_if_no_more_data(self, open_mock):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     self.assertRaises(SliceDeleted, ceres_slice.deleteBefore, 360)
@@ -762,7 +768,7 @@ class CeresSliceTest(TestCase):
   def test_delete_before_seeks_to_time(self):
     ceres_slice = CeresSlice(self.ceres_node, 300, 60)
     open_mock = mock_open(read_data='foo')
-    with patch('__builtin__.open', open_mock) as open_mock:
+    with patch.object(builtins, 'open', open_mock) as open_mock:
       ceres_slice.deleteBefore(360)
       # Seek from 300 (start of file) to 360 (1 datapointpoint)
       open_mock.return_value.seek.assert_any_call(1 * DATAPOINT_SIZE)
@@ -788,7 +794,7 @@ class CeresSliceWriteTest(TestCase):
     self.assertRaises(SliceDeleted, self.ceres_slice.write, [(0, 0)])
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', mock_open())
+  @patch.object(builtins, 'open', mock_open())
   def test_raises_slice_gap_too_large_when_it_is(self):
     # one point over the max
     new_time = self.ceres_slice.startTime + self.ceres_slice.timeStep * (MAX_SLICE_GAP + 1)
@@ -796,7 +802,7 @@ class CeresSliceWriteTest(TestCase):
     self.assertRaises(SliceGapTooLarge, self.ceres_slice.write, [datapoint])
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', mock_open())
+  @patch.object(builtins, 'open', mock_open())
   def test_doesnt_raise_slice_gap_too_large_when_it_isnt(self):
     new_time = self.ceres_slice.startTime + self.ceres_slice.timeStep * (MAX_SLICE_GAP - 1)
     datapoint = (new_time, 0)
@@ -806,7 +812,7 @@ class CeresSliceWriteTest(TestCase):
       self.fail("SliceGapTooLarge raised")
 
   @patch('ceres.getsize', Mock(return_value=DATAPOINT_SIZE * 100))
-  @patch('__builtin__.open', mock_open())
+  @patch.object(builtins, 'open', mock_open())
   def test_doesnt_raise_slice_gap_when_newer_points_exist(self):
     new_time = self.ceres_slice.startTime + self.ceres_slice.timeStep * (MAX_SLICE_GAP + 1)
     datapoint = (new_time, 0)
@@ -816,33 +822,33 @@ class CeresSliceWriteTest(TestCase):
       self.fail("SliceGapTooLarge raised")
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_raises_ioerror_if_seek_hits_ioerror(self, open_mock):
     open_mock.return_value.seek.side_effect = IOError
     self.assertRaises(IOError, self.ceres_slice.write, [(300, 0)])
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_opens_file_as_binary(self, open_mock):
     self.ceres_slice.write([(300, 0)])
     # call_args = (args, kwargs)
     self.assertTrue(open_mock.call_args[0][1].endswith('b'))
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_seeks_to_the_correct_offset_first_point(self, open_mock):
     self.ceres_slice.write([(300, 0)])
     open_mock.return_value.seek.assert_called_once_with(0)
 
   @patch('ceres.getsize', Mock(return_value=1 * DATAPOINT_SIZE))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_seeks_to_the_correct_offset_next_point(self, open_mock):
     self.ceres_slice.write([(360, 0)])
     # 2nd point in the file
     open_mock.return_value.seek.assert_called_once_with(DATAPOINT_SIZE)
 
   @patch('ceres.getsize', Mock(return_value=1 * DATAPOINT_SIZE))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_seeks_to_the_next_empty_offset_one_point_gap(self, open_mock):
     # Gaps are written out as NaNs so the offset we expect is the beginning
     # of the gap, not the offset of the point itself
@@ -850,19 +856,19 @@ class CeresSliceWriteTest(TestCase):
     open_mock.return_value.seek.assert_called_once_with(1 * DATAPOINT_SIZE)
 
   @patch('ceres.getsize', Mock(return_value=0))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_correct_size_written_first_point(self, open_mock):
     self.ceres_slice.write([(300, 0)])
     self.assertEqual(1 * DATAPOINT_SIZE, len(fetch_mock_open_writes(open_mock)))
 
   @patch('ceres.getsize', Mock(return_value=1 * DATAPOINT_SIZE))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_correct_size_written_next_point(self, open_mock):
     self.ceres_slice.write([(360, 0)])
     self.assertEqual(1 * DATAPOINT_SIZE, len(fetch_mock_open_writes(open_mock)))
 
   @patch('ceres.getsize', Mock(return_value=1 * DATAPOINT_SIZE))
-  @patch('__builtin__.open', new_callable=mock_open)
+  @patch.object(builtins, 'open', new_callable=mock_open)
   def test_correct_size_written_one_point_gap(self, open_mock):
     self.ceres_slice.write([(420, 0)])
     # one empty point, one real point = two points total written


### PR DESCRIPTION
Python3 support (maintaining 2.7 compatibility)
 - use floor division for anything expecting an integer (all of 'em)
 - pull izip() out of itertools in 2.7 and alias zip() instead in 3.x
 - change mock open calls to patch.object the builtin module (\_\_builtin\_\_ in 2.7, builtins in 3.x) 
 - use next(<iterator>) vs <iterator>.next()
 - use range() instead of xrange()
 - use octal permissions
 - deal with python3 bytes vs str types when reading what was written to mock open