### PR TITLE
Align timestamps in deleteBefore.

### DIFF
--- a/ceres.py
+++ b/ceres.py
@@ -807,7 +807,8 @@ class CeresSlice(object):
     if not exists(self.fsPath):
       raise SliceDeleted()
 
-    t = t - (t % self.timeStep)
+    if t % self.timeStep != 0:
+      t = t - (t % self.timeStep) + self.timeStep
     timeOffset = t - self.startTime
     if timeOffset < 0:
       return


### PR DESCRIPTION
Closes #25 

Checking my local patches, looks like it's still applied here, however I'm unsure how useful it is since switching to a different rollup plugin, but if I've not noticed any oddities, then should be fine.